### PR TITLE
Add project name support and paginated PDF export

### DIFF
--- a/harper_calc/report.py
+++ b/harper_calc/report.py
@@ -3,17 +3,38 @@
 from reportlab.lib.pagesizes import letter
 from reportlab.pdfgen import canvas
 
+PAGE_WIDTH, PAGE_HEIGHT = letter
+
 from .calculator import SiteData, format_breakdown
 
 
-def export_pdf(result: dict, filepath: str, *, data: SiteData | None = None) -> None:
+def export_pdf(
+    result: dict,
+    filepath: str,
+    *,
+    data: SiteData | None = None,
+    project_name: str | None = None,
+    left_margin: float = 0.5,
+    right_margin: float = 0.5,
+    top_margin: float = 1.0,
+    bottom_margin: float = 1.0,
+) -> None:
     """Export calculation results to a PDF file."""
     c = canvas.Canvas(str(filepath), pagesize=letter)
 
-    text = c.beginText(72, 720)
+    line_height = 14
+    x = left_margin * 72
+    y = PAGE_HEIGHT - top_margin * 72
+    text = c.beginText(x, y)
     text.setFont("Helvetica", 12)
+    text.setLeading(line_height)
     text.textLine("Harper Nutrient Loading Results")
+    y -= line_height
+    if project_name:
+        text.textLine(f"Project: {project_name}")
+        y -= line_height
     text.textLine("")
+    y -= line_height
     ordered = [
         ("runoff_volume_m3", "Runoff Volume (m^3)"),
         ("TN_kg_per_yr", "TN Load (kg/yr)"),
@@ -23,11 +44,32 @@ def export_pdf(result: dict, filepath: str, *, data: SiteData | None = None) -> 
     ]
     for key, label in ordered:
         if key in result:
+            if y <= bottom_margin * 72:
+                c.drawText(text)
+                c.showPage()
+                y = PAGE_HEIGHT - top_margin * 72
+                text = c.beginText(x, y)
+                text.setFont("Helvetica", 12)
             text.textLine(f"{label}: {result[key]:.2f}")
+            y -= line_height
     if data is not None:
+        if y <= bottom_margin * 72:
+            c.drawText(text)
+            c.showPage()
+            y = PAGE_HEIGHT - top_margin * 72
+            text = c.beginText(x, y)
+            text.setFont("Helvetica", 12)
         text.textLine("")
+        y -= line_height
         for line in format_breakdown(data, result).splitlines():
+            if y <= bottom_margin * 72:
+                c.drawText(text)
+                c.showPage()
+                y = PAGE_HEIGHT - top_margin * 72
+                text = c.beginText(x, y)
+                text.setFont("Helvetica", 12)
             text.textLine(line)
+            y -= line_height
 
     c.drawText(text)
     c.showPage()

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -7,11 +7,24 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from harper_calc.report import export_pdf
 from harper_calc.calculator import SiteData, calculate_site_loads
+from PyPDF2 import PdfReader
 
 
 def test_export_pdf(tmp_path):
     data = SiteData(1.0, 1.0, 0.5, 2.0, 0.5)
     result = calculate_site_loads(data)
     pdf_path = tmp_path / "result.pdf"
-    export_pdf(result, pdf_path, data=data)
+    export_pdf(
+        result,
+        pdf_path,
+        data=data,
+        project_name="Test Project",
+        left_margin=0.75,
+        right_margin=0.75,
+        top_margin=1.25,
+        bottom_margin=1.25,
+    )
     assert pdf_path.exists() and pdf_path.stat().st_size > 0
+    reader = PdfReader(str(pdf_path))
+    text = "".join(page.extract_text() or "" for page in reader.pages)
+    assert "Test Project" in text


### PR DESCRIPTION
## Summary
- paginate PDF exports with standard 8.5"x11" margins
- add optional project name to PDF header
- include project name entry in GUI and pass to PDF
- test project name is written into exported PDF

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862d014bec08320a3ae2614b448640f